### PR TITLE
Add an action to automatically deploy changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,144 @@
+name: Build and publish testing version
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Source code branch to publish'
+        required: true
+        type: string
+        default: 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.grab-commit.outputs.commit }}
+    steps:
+      - name: Check out the main branch of source repository
+        uses: actions/checkout@v4
+        with:
+          repository: ultraabox/ultrabox_typescript
+          ref: ${{ inputs.source_branch }}
+      - name: Install Node.js and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: |
+          npm ci
+      - name: Build
+        run: |
+          npm run build
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: new_website_contents
+          # @TODO: Move this into a script that lives in the source repository,
+          # that way there's only one place to update in case this list
+          # changes.
+          path: |
+            website/beepbox_editor.min.js
+            website/service_worker.js
+            website/drumsamples.js
+            website/kirby_samples.js
+            website/samples.js
+            website/samples2.js
+            website/samples3.js
+            website/wario_samples.js
+            website/mario_paintbox_samples.js
+            website/nintaribox_samples.js
+            website/index.html
+            website/favicon.ico
+            website/icon_32.png
+            website/hotdog.png
+            website/404.html
+            website/credits.html
+            website/patch_notes.html
+            website/sample_extractor.html
+            website/beepbox_synth.min.js
+            website/synth_example.html
+            website/player/beepbox_player.min.js
+            website/player/drumsamples.js
+            website/player/kirby_samples.js
+            website/player/samples.js
+            website/player/samples2.js
+            website/player/samples3.js
+            website/player/wario_samples.js
+            website/player/mario_paintbox_samples.js
+            website/player/nintaribox_samples.js
+            website/player/index.html
+            website/player/404.html
+            website/theme_resources/AzurLaneThemeLogo.png
+            website/theme_resources/AzurLaneThemeMemoryTaskBackground.png
+            website/theme_resources/AzurLaneThemeMouse.png
+            website/theme_resources/AzurLaneThemeStarterSquad.png
+            website/theme_resources/abyssbox_border.png
+            website/theme_resources/abyssbox_border_light.png
+            website/theme_resources/abyssbox_cursor.png
+            website/theme_resources/abyssbox_cursor_hand.png
+            website/theme_resources/abysstype.otf
+            website/theme_resources/abysstype_small.otf
+            website/theme_resources/icon-SelectAll.png
+            website/theme_resources/icon-copy.png
+            website/theme_resources/icon-deleteChannel.png
+            website/theme_resources/icon-duplicate.png
+            website/theme_resources/icon-edit.png
+            website/theme_resources/icon-export.png
+            website/theme_resources/icon-file.png
+            website/theme_resources/icon-fullscreen.png
+            website/theme_resources/icon-import.png
+            website/theme_resources/icon-insertChannel.png
+            website/theme_resources/icon-next.png
+            website/theme_resources/icon-paste.png
+            website/theme_resources/icon-pause.png
+            website/theme_resources/icon-play.png
+            website/theme_resources/icon-preferences.png
+            website/theme_resources/icon-prev.png
+            website/theme_resources/icon-record.png
+            website/theme_resources/icon-redo.png
+            website/theme_resources/icon-singleBarLoop.png
+            website/theme_resources/icon-speaker.png
+            website/theme_resources/icon-speakerMuted.png
+            website/theme_resources/icon-stop.png
+            website/theme_resources/icon-undo.png
+            website/theme_resources/icon-zoomIn.png
+            website/theme_resources/icon-zoomOut.png
+            website/theme_resources/moveNotesDown.png
+            website/theme_resources/moveNotesUp.png
+            website/theme_resources/stripesbg.gif
+            website/theme_resources/stripesbg_light.gif
+            website/theme_resources/wackybox_cursor.png
+      - name: Grab current commit hash
+        id: grab-commit
+        run: |
+          echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out testing website repository
+        uses: actions/checkout@v4
+      - name: Download and unpack artifact with new website contents
+        uses: actions/download-artifact@v4
+        with:
+          name: new_website_contents
+      # - name: Push directly to main branch
+      #   run: |
+      #     git config --global user.name "github-actions[bot]"
+      #     git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      #     git add --all
+      #     git commit -m "Sync with latest changes" -m "https://github.com/ultraabox/ultrabox_typescript/commit/${{ needs.build.outputs.commit }}"
+      #     git push origin main
+      - name: Make a pull request with the build
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: automated-release
+          delete-branch: true
+          commit-message: |
+            Sync with latest changes
+
+            https://github.com/ultraabox/ultrabox_typescript/commit/${{ needs.build.outputs.commit }}
+          title: Sync with latest changes


### PR DESCRIPTION
For safety, the changes are sent via a pull request. That said, there's some commented out code (that I have tested) that pushes directly to the main branch, if the extra merge is too much of a bother.

Sadly, GitHub doesn't give me the ability to show a proper branch dropdown, so picking the [ultrabox_typescript](https://github.com/ultraabox/ultrabox_typescript) branch has to be done by typing in the branch name manually.

This action is executed manually, by going to the Actions tab, and clicking on "Run workflow" here:

![ub_testing_actions1](https://github.com/ultraabox/testing/assets/11607580/058c963d-cc18-4e8d-8445-3dc48ff79cf9)

...though, before you do that, you have to adjust the settings [here](https://github.com/ultraabox/testing/settings/actions), ticking "Read and write permissions" and "Allow GitHub Actions to create and approve pull requests", otherwise neither of these will work.

If this works well, it can be done for the main website repository too.